### PR TITLE
[WF-191] Add environment file under 3.1.0/ and source it in services

### DIFF
--- a/3.1.0/rockcraft.yaml
+++ b/3.1.0/rockcraft.yaml
@@ -10,7 +10,6 @@ platforms:
   amd64:
 environment:
   AIRFLOW_HOME: /var/lib/airflow
-  PYTHONPATH: /usr/lib/python3
 
 services:
   airflow:
@@ -31,7 +30,7 @@ parts:
     source-type: git
     source-tag: 3.1.0
     stage-packages:
-      - python3.12-venv
+      - python3-venv
   airflow-license:
     plugin: dump
     source: https://github.com/apache/airflow


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR introduces a dedicated `environment` file under to manage environment variables instead of defining them inline within Pebble services.

- Added `3.1.0/environment` containing all required environment variables.
- Updated `3.1.0/rockcraft.yaml` to stage `/etc/profile.d/environment.sh` via the `env_stage` part.
- Removed `environment:` blocks from service definitions.
- Ensures all services consistently load environment variables from the same source at runtime.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->


