### PR TITLE
[WF-230] Move AIRFLOW_HOME to /opt

### DIFF
--- a/3.1.0/goss.yaml
+++ b/3.1.0/goss.yaml
@@ -103,23 +103,23 @@ file:
     owner: root
     group: root
     mode: "0755"
-  /var/lib/airflow:
+  /opt/airflow:
     exists: true
-    path: /var/lib/airflow
+    path: /opt/airflow
     filetype: directory
     owner: root
     group: root
     mode: "0755"
-  /var/lib/airflow/airflow.cfg:
+  /opt/airflow/airflow.cfg:
     exists: true
-    path: /var/lib/airflow/airflow.cfg
+    path: /opt/airflow/airflow.cfg
     owner: root
     group: root
     filetype: file
     mode: "0600"
-  /var/lib/airflow/logs:
+  /opt/airflow/logs:
     exists: true
-    path: /var/lib/airflow/logs
+    path: /opt/airflow/logs
     filetype: directory
     owner: root
     group: root

--- a/3.1.0/rockcraft.yaml
+++ b/3.1.0/rockcraft.yaml
@@ -9,7 +9,7 @@ build-base: ubuntu@24.04
 platforms:
   amd64:
 environment:
-  AIRFLOW_HOME: /var/lib/airflow
+  AIRFLOW_HOME: /opt/airflow
 
 services:
   airflow:


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR updates AIRFLOW_HOME from /var/lib/airflow to /opt/airflow.
Rationale:
- Aligns the Airflow Rock with upstream Airflow Docker images, which standardize on /opt/airflow.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

Changes included:
- Updated AIRFLOW_HOME environment variable.
- Adjusted file paths and references accordingly.
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated

