### PR TITLE
[WF-231] Add rock signature file for build identity verification

### DIFF
--- a/3.1.0/goss.yaml
+++ b/3.1.0/goss.yaml
@@ -88,13 +88,13 @@ command:
       - "apache-airflow-providers-trino | 6.3.3"
       - "apache-airflow-providers-vertica | 4.1.2"
   rock-signature-valid-json:
-    exec: "python3 -m json.tool /opt/airflow/rock-signature > /dev/null"
+    exec: "python3 -m json.tool /opt/airflow/rock-signature || echo 'Invalid JSON in rock-signature'"
     exit-status: 0
   rock-signature-version-match:
-    exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); assert sig['version'] == '3.1.0'\""
+    exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); v=sig['version']; assert v == '3.1.0', f'Version mismatch: {v}'\""
     exit-status: 0
   rock-signature-has-valid-md5:
-    exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); assert len(sig['md5']) == 32\""
+    exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); m=sig['md5']; assert len(m) == 32, f'Invalid MD5 length: {len(m)}'\""
     exit-status: 0
 
 file:

--- a/3.1.0/goss.yaml
+++ b/3.1.0/goss.yaml
@@ -144,6 +144,27 @@ file:
     filetype: file
     owner: root
     group: root
+  /opt/airflow/rock-signature:
+    exists: true
+    mode: "0644"
+    filetype: file
+    owner: root
+    group: root
+    contains:
+      - '"version"'
+      - '"md5"'
+      - '"build_timestamp"'
+
+command:
+  rock-signature-valid-json:
+    exec: "python3 -m json.tool /opt/airflow/rock-signature > /dev/null"
+    exit-status: 0
+  rock-signature-version-match:
+    exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); assert sig['version'] == '3.1.0'\""
+    exit-status: 0
+  rock-signature-has-valid-md5:
+    exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); assert len(sig['md5']) == 32\""
+    exit-status: 0
 
 http:
   "http://127.0.0.1:8080/api/v2/monitor/health":

--- a/3.1.0/goss.yaml
+++ b/3.1.0/goss.yaml
@@ -87,6 +87,15 @@ command:
       - "apache-airflow-providers-standard | 1.8.0"
       - "apache-airflow-providers-trino | 6.3.3"
       - "apache-airflow-providers-vertica | 4.1.2"
+  rock-signature-valid-json:
+    exec: "python3 -m json.tool /opt/airflow/rock-signature > /dev/null"
+    exit-status: 0
+  rock-signature-version-match:
+    exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); assert sig['version'] == '3.1.0'\""
+    exit-status: 0
+  rock-signature-has-valid-md5:
+    exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); assert len(sig['md5']) == 32\""
+    exit-status: 0
 
 file:
   /bin/airflow:
@@ -154,17 +163,6 @@ file:
       - '"version"'
       - '"md5"'
       - '"build_timestamp"'
-
-command:
-  rock-signature-valid-json:
-    exec: "python3 -m json.tool /opt/airflow/rock-signature > /dev/null"
-    exit-status: 0
-  rock-signature-version-match:
-    exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); assert sig['version'] == '3.1.0'\""
-    exit-status: 0
-  rock-signature-has-valid-md5:
-    exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); assert len(sig['md5']) == 32\""
-    exit-status: 0
 
 http:
   "http://127.0.0.1:8080/api/v2/monitor/health":

--- a/3.1.0/rockcraft.yaml
+++ b/3.1.0/rockcraft.yaml
@@ -95,4 +95,27 @@ parts:
     source-type: git
     source-branch: main
     override-prime: gen_manifest
+  airflow-signature:
+    plugin: nil
+    after:
+      - airflow
+    override-stage: |
+      AIRFLOW_VERSION="${CRAFT_PROJECT_VERSION}"
+
+      AIRFLOW_MD5=$(find ${CRAFT_STAGE}/lib/python3.12/site-packages \
+        \( -name "airflow" -o -name "apache_airflow*" \) \
+        -type d -exec find {} -type f \; 2>/dev/null \
+        | sort | xargs md5sum 2>/dev/null | md5sum | cut -d' ' -f1)
+
+      BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+      mkdir -p ${CRAFT_PART_INSTALL}/opt/airflow
+
+      python3 -c "import json; print(json.dumps({'version': '${AIRFLOW_VERSION}', 'md5': '${AIRFLOW_MD5}', 'build_timestamp': '${BUILD_TIMESTAMP}'}, indent=2))" > ${CRAFT_PART_INSTALL}/opt/airflow/rock-signature
+
+      chmod 0644 ${CRAFT_PART_INSTALL}/opt/airflow/rock-signature
+
+      craftctl default
+    stage:
+      - opt/airflow/rock-signature
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Add a rock signature file to enable build identity verification for Charmed Airflow deployments.
This PR adds a mechanism to verify build consistency across components.

### Changes

**`3.1.0/rockcraft.yaml`:**
- Added `airflow-signature` part that generates `/opt/airflow/rock-signature` containing:
  ```json
  {
    "version": "3.1.0",
    "md5": "777d209a99a514438c285aa6d3b27c45",
    "build_timestamp": "2026-01-14T09:16:16Z"
  }

**`3.1.0/goss.yaml`:**
Added file existence and permissions test for /opt/airflow/rock-signature
Added JSON validation tests (valid format, version match, MD5 length)

**How the MD5 is calculated:**
The hash is computed from all airflow-related packages in site-packages:

``` 
  find ${CRAFT_STAGE}/lib/python3.12/site-packages \
  \( -name "airflow" -o -name "apache_airflow*" \) \
  -type d -exec find {} -type f \; | sort | xargs md5sum | md5sum
```


<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Closes #13 
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

Build the rock:
`just pack 3.1.0`

Load into Docker and verify signature:
```bash
sudo rockcraft.skopeo --insecure-policy copy oci-archive:3.1.0/airflow_3.1.0_amd64.rock docker-daemon:airflow-rock:test
sudo docker run --rm --entrypoint cat airflow-rock:test /opt/airflow/rock-signature
```

Expected output:
```json
{
  "version": "3.1.0",
  "md5": "<32-character-hash>",
  "build_timestamp": "<ISO-8601-timestamp>"
}
```

Run full test suite:
`just test 3.1.0`


## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [X] Integration tests added or updated
- [ ] Documentation updated

