### PR TITLE
[WF-294] Make ubuntu as the owner of AIRFLOW_HOME

### DIFF
--- a/3.1.0/goss.yaml
+++ b/3.1.0/goss.yaml
@@ -12,6 +12,11 @@ command:
     exit-status: 0
     stdout:
       - '1'
+  airflow-standalone-user:
+    exec: "sh -lc \"ps -eo user,cmd | grep -F 'airflow standalone' | grep -v grep | awk 'NR==1{print $1}'\""
+    exit-status: 0
+    stdout:
+      - 'ubuntu'
   default-executor-is-local:
     exec: "/bin/airflow config get-value core executor"
     exit-status: 0
@@ -96,6 +101,15 @@ command:
   rock-signature-has-valid-md5:
     exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); m=sig['md5']; assert len(m) == 32, f'Invalid MD5 length: {len(m)}'\""
     exit-status: 0
+  airflow-home-owned-by-1000:
+    exec: "sh -lc \"[ $(stat -c '%u:%g' /opt/airflow) = 1000:1000 ]\""
+    exit-status: 0
+  airflow-logs-owned-by-1000:
+    exec: "sh -lc \"[ $(stat -c '%u:%g' /opt/airflow/logs) = 1000:1000 ]\""
+    exit-status: 0
+  airflow-signature-owned-by-1000:
+    exec: "sh -lc \"[ $(stat -c '%u:%g' /opt/airflow/rock-signature) = 1000:1000 ]\""
+    exit-status: 0
 
 file:
   /bin/airflow:
@@ -116,22 +130,22 @@ file:
     exists: true
     path: /opt/airflow
     filetype: directory
-    owner: root
-    group: root
+    owner: ubuntu
+    group: ubuntu
     mode: "0755"
   /opt/airflow/airflow.cfg:
     exists: true
     path: /opt/airflow/airflow.cfg
-    owner: root
-    group: root
+    owner: ubuntu
+    group: ubuntu
     filetype: file
     mode: "0600"
   /opt/airflow/logs:
     exists: true
     path: /opt/airflow/logs
     filetype: directory
-    owner: root
-    group: root
+    owner: ubuntu
+    group: ubuntu
     mode: "0755"
   /licenses/LICENSE-airflow:
     exists: true
@@ -157,12 +171,21 @@ file:
     exists: true
     mode: "0644"
     filetype: file
-    owner: root
-    group: root
+    owner: ubuntu
+    group: ubuntu
     contains:
       - '"version"'
       - '"md5"'
       - '"build_timestamp"'
+
+user:
+  root:
+    exists: true
+    uid: 0
+    gid: 0
+  ubuntu:
+    exists: true
+    home: /opt/airflow
 
 http:
   "http://127.0.0.1:8080/api/v2/monitor/health":

--- a/3.1.0/goss.yaml
+++ b/3.1.0/goss.yaml
@@ -101,15 +101,6 @@ command:
   rock-signature-has-valid-md5:
     exec: "python3 -c \"import json; sig=json.load(open('/opt/airflow/rock-signature')); m=sig['md5']; assert len(m) == 32, f'Invalid MD5 length: {len(m)}'\""
     exit-status: 0
-  airflow-home-owned-by-1000:
-    exec: "sh -lc \"[ $(stat -c '%u:%g' /opt/airflow) = 1000:1000 ]\""
-    exit-status: 0
-  airflow-logs-owned-by-1000:
-    exec: "sh -lc \"[ $(stat -c '%u:%g' /opt/airflow/logs) = 1000:1000 ]\""
-    exit-status: 0
-  airflow-signature-owned-by-1000:
-    exec: "sh -lc \"[ $(stat -c '%u:%g' /opt/airflow/rock-signature) = 1000:1000 ]\""
-    exit-status: 0
 
 file:
   /bin/airflow:
@@ -185,7 +176,8 @@ user:
     gid: 0
   ubuntu:
     exists: true
-    home: /opt/airflow
+    uid: 1000
+    gid: 1000
 
 http:
   "http://127.0.0.1:8080/api/v2/monitor/health":

--- a/3.1.0/goss.yaml
+++ b/3.1.0/goss.yaml
@@ -33,6 +33,7 @@ command:
     stdout:
       - "/^CeleryExecutor$/"
   providers-import-check:
+    timeout: 60000
     exec: |
       export PROVIDERS="$(
       airflow providers list --output plain \

--- a/3.1.0/goss.yaml
+++ b/3.1.0/goss.yaml
@@ -13,7 +13,7 @@ command:
     stdout:
       - '1'
   airflow-standalone-user:
-    exec: "sh -lc \"ps -eo user,cmd | grep -F 'airflow standalone' | grep -v grep | awk 'NR==1{print $1}'\""
+    exec: "sh -lc \"ps -o user= $(pgrep -f 'airflow standalone') | head -n 1\""
     exit-status: 0
     stdout:
       - 'ubuntu'

--- a/3.1.0/rockcraft.yaml
+++ b/3.1.0/rockcraft.yaml
@@ -15,6 +15,8 @@ services:
     override: replace
     startup: enabled
     command: /usr/bin/airflow standalone
+    user: ubuntu
+    group: ubuntu
 
 checks:
   airflow-running:
@@ -118,4 +120,12 @@ parts:
       craftctl default
     stage:
       - opt/airflow/rock-signature
+  airflow-permissions:
+    plugin: nil
+    after:
+      - airflow-signature
+    override-prime: |
+      set -e
+      mkdir -p ${CRAFT_PRIME}/opt/airflow/logs
+      chown -R 1000:1000 ${CRAFT_PRIME}/opt/airflow
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Currently the workloads in all airflow charms run as root and the files are all written as `root`. This PR aims to modify that and have ubuntu as the owner to /opt/airflow and run workloads.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
clone airflow-rocks
```
cd airflow-rocks/3.1.0
rockcraft pack
docker run -d -p 5000:5000 --name registry registry:2
rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
	  "oci-archive:airflow_3.1.0_amd64.rock" \
	  "docker://localhost:5000/airflow-rock-dev:3.1.0"

DIGEST="$(rockcraft.skopeo --insecure-policy inspect --tls-verify=false "docker://localhost:5000/airflow-rock-dev:3.1.0" | jq -r .Digest)"
	
IMAGE_REF="localhost:5000/airflow-rock-dev@${DIGEST}"
```
clone airflow-core-operators

```
juju add-model test

juju deploy postgresql-k8s --trust
juju deploy pgbouncer-k8s --trust
juju integrate postgresql-k8s pgbouncer-k8s

cd airflow-core-operators/charms

for c in api-server scheduler dag-processor triggerer
do 
    cd $c
    charmcraft pack
    juju deploy ./airflow-$c-k8s_amd64.charm --resource airflow-$c-image=$IMAGE_REF
    cd ../
done
```

Clone airflow-coordinator-k8s, checkout current branch
```
charmcraft pack
juju deploy ./airflow-coordinator-k8s_amd64.charm --resource airflow-coordinator-image=$IMAGE_REF

juju integrate airflow-coordinator-k8s:airflow-api-server airflow-api-server-k8s:airflow-api-server

for c in api-server scheduler triggerer dag-processor
do
    juju integrate airflow-coordinator-k8s:airflow-coordinator airflow-$c-k8s:airflow-coordinator
done
juju integrate airflow-coordinator-k8s pgbouncer-k8s
```
	  

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated

