### PR TITLE
feat: add arm64 arch

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,4 +12,4 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: lczyk/observability/.github/workflows/rock-pull-request.yaml@add-arm64-support
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v2

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,4 +12,4 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v2
+    uses: lczyk/observability/.github/workflows/rock-pull-request.yaml@add-arm64-support

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,4 +12,4 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: lczyk/observability/.github/workflows/rock-pull-request.yaml@add-arm64-support
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v1

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,4 +12,4 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v1
+    uses: lczyk/observability/.github/workflows/rock-pull-request.yaml@add-arm64-support

--- a/3.1/goss.yaml
+++ b/3.1/goss.yaml
@@ -1,5 +1,6 @@
 command:
   airflow-version:
+    timeout: 60000
     exec: "airflow version"
     exit-status: 0
     stdout:
@@ -18,16 +19,19 @@ command:
     stdout:
       - 'ubuntu'
   default-executor-is-local:
+    timeout: 60000
     exec: "/bin/airflow config get-value core executor"
     exit-status: 0
     stdout:
       - "/^(LocalExecutor|SequentialExecutor)$/"
   k8s-executor-env-override:
+    timeout: 60000
     exec: AIRFLOW__CORE__EXECUTOR=KubernetesExecutor /bin/airflow config get-value core executor
     exit-status: 0
     stdout:
       - "/^KubernetesExecutor$/"
   celery-executor-env-override:
+    timeout: 60000
     exec: AIRFLOW__CORE__EXECUTOR=CeleryExecutor /bin/airflow config get-value core executor
     exit-status: 0
     stdout:
@@ -51,12 +55,14 @@ command:
       PY
     exit-status: 0
   airflow-git-provider-dependencies:
+    timeout: 60000
     exec: pip freeze
     exit-status: 0
     stdout:
       - "GitPython==3.1.46"
       - "aiohttp==3.13.3"
   airflow-providers-list:
+    timeout: 60000
     exec: airflow providers list --output plain   | grep -v 'package_name'   | awk '/^apache-/{name=$1; version=$NF; print name" | "version}'
     exit-status: 0
     stdout:

--- a/3.1/rockcraft.yaml
+++ b/3.1/rockcraft.yaml
@@ -7,6 +7,7 @@ description: |
 base: ubuntu@24.04
 platforms:
   amd64:
+  arm64:
 environment:
   AIRFLOW_HOME: /opt/airflow
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -19,7 +19,7 @@ The following are dependencies to be able to develop and test changes to the Tem
 There are convenient snaps for all of the above dependencies besides goss and kgoss. The recommended way to install these until a goss snap is released would be:
 ```bash
 goss_base_url="https://github.com/goss-org/goss/releases/latest/download"
-curl -L ${goss_base_url}/goss-linux-amd64 -o /usr/local/bin/goss
+curl -L ${goss_base_url}/goss-linux-$(dpkg --print-architecture) -o /usr/local/bin/goss
 chmod +rx /usr/local/bin/goss
 curl -L ${goss_base_url}/kgoss -o /usr/local/bin/kgoss
 chmod +rx /usr/local/bin/kgoss
@@ -52,7 +52,7 @@ To build the Airflow Rock, go to the directory that corresponds to your desired 
 cd <major.minor>
 rockcraft pack
 
-This produces a .rock artifact (e.g., airflow-rock_<version>_amd64.rock) in the same directory.
+This produces a .rock artifact (e.g., airflow_<version>_<arch>.rock) in the same directory.
 
 ## Using the Justfile
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This will:
 
 * Fetch Airflow source from GitHub (`<version>` tag)
 * Build Airflow and providers into a Python environment
-* Package it as an OCI image wrapped in a `.rock` file (e.g., `airflow-rock_<version>_amd64.rock`)
+* Package it as an OCI image wrapped in a `.rock` file (e.g., `airflow_<version>_<arch>.rock`)
 
 ## Running and testing the rock
 
@@ -63,7 +63,7 @@ Once built, you can run the rock locally using `docker`:
 
 ```bash
 # Load the rock into your local Docker daemon
-rockcraft.skopeo --insecure-policy copy oci-archive:airflow-rock_<version>_amd64.rock docker-daemon:airflow-rock:<version>
+rockcraft.skopeo --insecure-policy copy oci-archive:airflow_<version>_<arch>.rock docker-daemon:airflow-rock:<version>
 # Run the rock
 docker run -it --rm -p 5000:5000 airflow-rock:<version>
 ```

--- a/justfile
+++ b/justfile
@@ -20,9 +20,10 @@ push-to-local-registry VERSION:
 	set -euxo pipefail
 
 	rock_version="$(cat $VERSION/rockcraft.yaml | yq '.version')"
+	arch="$(dpkg --print-architecture)"
 
 	rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-	  "oci-archive:${VERSION}/airflow_${rock_version}_amd64.rock" \
+	  "oci-archive:${VERSION}/airflow_${rock_version}_${arch}.rock" \
 	  "docker://localhost:5000/airflow-rock-dev:${rock_version}"
 
 pack VERSION DEBUG="":


### PR DESCRIPTION
## Description

PR with small patches which i needed to apply to build and test this rock on arm64 host. `just test` passes locally with `microk8s` testing backend. `goos` and `kgoos` work on arm64 w/out any changes just fine.

driveby added a longer timeout for tests (up to 1min form 10s) to fix amg64 flakiness: https://github.com/canonical/airflow-rocks/pull/26/commits/bd7afd55e6fd147458fe8dc0ba9b02778b3ec104

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [x] Integration tests added or updated
- [x] Documentation updated

